### PR TITLE
feat: externalize langgraph state to redis, unique request ID for traceability

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
     image: redis:8.2.1-alpine
     ports:
       - "6379:6379"
+    volumes:
+      - redis_data:/data
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s
@@ -44,6 +46,8 @@ services:
       - WEAVIATE_HOST=weaviate
       - REDIS_HOST=redis
       - TZ=Asia/Kolkata
+    volumes:
+      - ./data:/app/data
     depends_on:
       weaviate:
         condition: service_healthy
@@ -66,3 +70,7 @@ services:
     # This command runs the ingestion script and then the container exits.
     # In the cloud, this would be a scheduled task.
     command: ["python", "-m", "agentic_rag.scripts.run_ingestion"]
+
+# Define the named volume for Redis persistence
+volumes:
+  redis_data:

--- a/logging.ini
+++ b/logging.ini
@@ -23,6 +23,7 @@ formatter=json
 stream=ext://sys.stdout
 
 [formatter_json]
-class=pythonjsonlogger.jsonlogger.JsonFormatter
-# This format string defines the fields that will be in your JSON log
-format=%(asctime)s %(name)s %(levelname)s %(message)s %(filename)s %(funcName)s %(lineno)d
+# Point to the new custom formatter class
+class=agentic_rag.logging_config.CustomJsonFormatter
+# Define the fields. The formatter's add_fields method will populate request_id.
+format=%(asctime)s %(name)s %(levelname)s %(request_id)s %(message)s %(filename)s %(funcName)s %(lineno)d

--- a/poetry.lock
+++ b/poetry.lock
@@ -1507,6 +1507,22 @@ files = [
 jsonpointer = ">=1.9"
 
 [[package]]
+name = "jsonpath-ng"
+version = "1.7.0"
+description = "A final implementation of JSONPath for Python that aims to be standard compliant, including arithmetic and binary comparison operators and providing clear AST for metaprogramming."
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "jsonpath-ng-1.7.0.tar.gz", hash = "sha256:f6f5f7fd4e5ff79c785f1573b394043b39849fb2bb47bcead935d12b00beab3c"},
+    {file = "jsonpath_ng-1.7.0-py2-none-any.whl", hash = "sha256:898c93fc173f0c336784a3fa63d7434297544b7198124a68f9a3ef9597b0ae6e"},
+    {file = "jsonpath_ng-1.7.0-py3-none-any.whl", hash = "sha256:f3d7f9e848cba1b6da28c55b1c26ff915dc9e0b1ba7e752a53d6da8d5cbd00b6"},
+]
+
+[package.dependencies]
+ply = "*"
+
+[[package]]
 name = "jsonpointer"
 version = "3.0.0"
 description = "Identify specific nodes in a JSON document (RFC 6901)"
@@ -1782,6 +1798,24 @@ files = [
 [package.dependencies]
 langchain-core = ">=0.2.38"
 ormsgpack = ">=1.10.0"
+
+[[package]]
+name = "langgraph-checkpoint-redis"
+version = "0.1.1"
+description = "Redis implementation of the LangGraph agent checkpoint saver and store."
+optional = false
+python-versions = "<3.14,>=3.9"
+groups = ["main"]
+files = [
+    {file = "langgraph_checkpoint_redis-0.1.1-py3-none-any.whl", hash = "sha256:ac59e28b949b308dc4c1a0d0c4e11affb3d9b495e46d152d593b89a8e55338b8"},
+    {file = "langgraph_checkpoint_redis-0.1.1.tar.gz", hash = "sha256:2663a3c138c6aaeeafa28de76d78d4e693bf7722fdc99ff291525f6aa1c986f3"},
+]
+
+[package.dependencies]
+langgraph-checkpoint = ">=2.0.21,<3.0.0"
+orjson = ">=3.9.0,<4.0.0"
+redis = ">=6.2.0,<7.0.0"
+redisvl = ">=0.5.1,<1.0.0"
 
 [[package]]
 name = "langgraph-prebuilt"
@@ -2064,6 +2098,57 @@ packaging = ">=17.0"
 dev = ["marshmallow[tests]", "pre-commit (>=3.5,<5.0)", "tox"]
 docs = ["autodocsumm (==0.2.14)", "furo (==2024.8.6)", "sphinx (==8.1.3)", "sphinx-copybutton (==0.5.2)", "sphinx-issues (==5.0.0)", "sphinxext-opengraph (==0.9.1)"]
 tests = ["pytest", "simplejson"]
+
+[[package]]
+name = "ml-dtypes"
+version = "0.5.3"
+description = "ml_dtypes is a stand-alone implementation of several NumPy dtype extensions used in machine learning."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "ml_dtypes-0.5.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0a1d68a7cb53e3f640b2b6a34d12c0542da3dd935e560fdf463c0c77f339fc20"},
+    {file = "ml_dtypes-0.5.3-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0cd5a6c711b5350f3cbc2ac28def81cd1c580075ccb7955e61e9d8f4bfd40d24"},
+    {file = "ml_dtypes-0.5.3-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bdcf26c2dbc926b8a35ec8cbfad7eff1a8bd8239e12478caca83a1fc2c400dc2"},
+    {file = "ml_dtypes-0.5.3-cp310-cp310-win_amd64.whl", hash = "sha256:aecbd7c5272c82e54d5b99d8435fd10915d1bc704b7df15e4d9ca8dc3902be61"},
+    {file = "ml_dtypes-0.5.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:4a177b882667c69422402df6ed5c3428ce07ac2c1f844d8a1314944651439458"},
+    {file = "ml_dtypes-0.5.3-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9849ce7267444c0a717c80c6900997de4f36e2815ce34ac560a3edb2d9a64cd2"},
+    {file = "ml_dtypes-0.5.3-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c3f5ae0309d9f888fd825c2e9d0241102fadaca81d888f26f845bc8c13c1e4ee"},
+    {file = "ml_dtypes-0.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:58e39349d820b5702bb6f94ea0cb2dc8ec62ee81c0267d9622067d8333596a46"},
+    {file = "ml_dtypes-0.5.3-cp311-cp311-win_arm64.whl", hash = "sha256:66c2756ae6cfd7f5224e355c893cfd617fa2f747b8bbd8996152cbdebad9a184"},
+    {file = "ml_dtypes-0.5.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:156418abeeda48ea4797db6776db3c5bdab9ac7be197c1233771e0880c304057"},
+    {file = "ml_dtypes-0.5.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1db60c154989af253f6c4a34e8a540c2c9dce4d770784d426945e09908fbb177"},
+    {file = "ml_dtypes-0.5.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1b255acada256d1fa8c35ed07b5f6d18bc21d1556f842fbc2d5718aea2cd9e55"},
+    {file = "ml_dtypes-0.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:da65e5fd3eea434ccb8984c3624bc234ddcc0d9f4c81864af611aaebcc08a50e"},
+    {file = "ml_dtypes-0.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:8bb9cd1ce63096567f5f42851f5843b5a0ea11511e50039a7649619abfb4ba6d"},
+    {file = "ml_dtypes-0.5.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:5103856a225465371fe119f2fef737402b705b810bd95ad5f348e6e1a6ae21af"},
+    {file = "ml_dtypes-0.5.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4cae435a68861660af81fa3c5af16b70ca11a17275c5b662d9c6f58294e0f113"},
+    {file = "ml_dtypes-0.5.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6936283b56d74fbec431ca57ce58a90a908fdbd14d4e2d22eea6d72bb208a7b7"},
+    {file = "ml_dtypes-0.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:d0f730a17cf4f343b2c7ad50cee3bd19e969e793d2be6ed911f43086460096e4"},
+    {file = "ml_dtypes-0.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:2db74788fc01914a3c7f7da0763427280adfc9cd377e9604b6b64eb8097284bd"},
+    {file = "ml_dtypes-0.5.3-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:93c36a08a6d158db44f2eb9ce3258e53f24a9a4a695325a689494f0fdbc71770"},
+    {file = "ml_dtypes-0.5.3-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0e44a3761f64bc009d71ddb6d6c71008ba21b53ab6ee588dadab65e2fa79eafc"},
+    {file = "ml_dtypes-0.5.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bdf40d2aaabd3913dec11840f0d0ebb1b93134f99af6a0a4fd88ffe924928ab4"},
+    {file = "ml_dtypes-0.5.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:aec640bd94c4c85c0d11e2733bd13cbb10438fb004852996ec0efbc6cacdaf70"},
+    {file = "ml_dtypes-0.5.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bda32ce212baa724e03c68771e5c69f39e584ea426bfe1a701cb01508ffc7035"},
+    {file = "ml_dtypes-0.5.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c205cac07d24a29840c163d6469f61069ce4b065518519216297fc2f261f8db9"},
+    {file = "ml_dtypes-0.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:cd7c0bb22d4ff86d65ad61b5dd246812e8993fbc95b558553624c33e8b6903ea"},
+    {file = "ml_dtypes-0.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:9d55ea7f7baf2aed61bf1872116cefc9d0c3693b45cae3916897ee27ef4b835e"},
+    {file = "ml_dtypes-0.5.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:e12e29764a0e66a7a31e9b8bf1de5cc0423ea72979f45909acd4292de834ccd3"},
+    {file = "ml_dtypes-0.5.3-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19f6c3a4f635c2fc9e2aa7d91416bd7a3d649b48350c51f7f715a09370a90d93"},
+    {file = "ml_dtypes-0.5.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ab039ffb40f3dc0aeeeba84fd6c3452781b5e15bef72e2d10bcb33e4bbffc39"},
+    {file = "ml_dtypes-0.5.3-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5ee72568d46b9533ad54f78b1e1f3067c0534c5065120ea8ecc6f210d22748b3"},
+    {file = "ml_dtypes-0.5.3-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01de48de4537dc3c46e684b969a40ec36594e7eeb7c69e9a093e7239f030a28a"},
+    {file = "ml_dtypes-0.5.3-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8b1a6e231b0770f2894910f1dce6d2f31d65884dbf7668f9b08d73623cdca909"},
+    {file = "ml_dtypes-0.5.3-cp39-cp39-win_amd64.whl", hash = "sha256:a4f39b9bf6555fab9bfb536cf5fdd1c1c727e8d22312078702e9ff005354b37f"},
+    {file = "ml_dtypes-0.5.3.tar.gz", hash = "sha256:95ce33057ba4d05df50b1f3cfefab22e351868a843b3b15a46c65836283670c9"},
+]
+
+[package.dependencies]
+numpy = {version = ">=1.26.0", markers = "python_version >= \"3.12\""}
+
+[package.extras]
+dev = ["absl-py", "pyink", "pylint (>=2.6.0)", "pytest", "pytest-xdist"]
 
 [[package]]
 name = "mpmath"
@@ -3017,6 +3102,18 @@ dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
+name = "ply"
+version = "3.11"
+description = "Python Lex & Yacc"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce"},
+    {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
+]
+
+[[package]]
 name = "propcache"
 version = "0.3.2"
 description = "Accelerated property cache"
@@ -3583,6 +3680,21 @@ files = [
 dev = ["backports.zoneinfo ; python_version < \"3.9\"", "black", "build", "freezegun", "mdx_truly_sane_lists", "mike", "mkdocs", "mkdocs-awesome-pages-plugin", "mkdocs-gen-files", "mkdocs-literate-nav", "mkdocs-material (>=8.5)", "mkdocstrings[python]", "msgspec ; implementation_name != \"pypy\"", "mypy", "orjson ; implementation_name != \"pypy\"", "pylint", "pytest", "tzdata", "validate-pyproject[all]"]
 
 [[package]]
+name = "python-ulid"
+version = "3.1.0"
+description = "Universally unique lexicographically sortable identifier"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "python_ulid-3.1.0-py3-none-any.whl", hash = "sha256:e2cdc979c8c877029b4b7a38a6fba3bc4578e4f109a308419ff4d3ccf0a46619"},
+    {file = "python_ulid-3.1.0.tar.gz", hash = "sha256:ff0410a598bc5f6b01b602851a3296ede6f91389f913a5d5f8c496003836f636"},
+]
+
+[package.extras]
+pydantic = ["pydantic (>=2.0)"]
+
+[[package]]
 name = "pytz"
 version = "2025.2"
 description = "World timezone definitions, modern and historical"
@@ -3688,6 +3800,55 @@ all = ["datacompy", "llama_index", "nltk", "pandas", "r2r", "ragas-experimental"
 dev = ["black[jupyter]", "datacompy", "fastembed", "graphene", "haystack-ai", "llama_index", "nbmake", "nltk", "notebook", "pandas", "pyright", "pytest", "pytest-asyncio", "pytest-xdist[psutil]", "r2r", "rapidfuzz", "rich", "rouge_score", "ruff", "sacrebleu", "sentence-transformers", "sphinx-autobuild", "transformers"]
 docs = ["mkdocs (>=1.6.1)", "mkdocs-autorefs", "mkdocs-gen-files", "mkdocs-git-committers-plugin-2", "mkdocs-git-revision-date-localized-plugin", "mkdocs-glightbox", "mkdocs-literate-nav", "mkdocs-material", "mkdocs-material[imaging]", "mkdocs-section-index", "mkdocstrings[python]"]
 experimental = ["ragas-experimental"]
+
+[[package]]
+name = "redis"
+version = "6.4.0"
+description = "Python client for Redis database and key-value store"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "redis-6.4.0-py3-none-any.whl", hash = "sha256:f0544fa9604264e9464cdf4814e7d4830f74b165d52f2a330a760a88dd248b7f"},
+    {file = "redis-6.4.0.tar.gz", hash = "sha256:b01bc7282b8444e28ec36b261df5375183bb47a07eb9c603f284e89cbc5ef010"},
+]
+
+[package.extras]
+hiredis = ["hiredis (>=3.2.0)"]
+jwt = ["pyjwt (>=2.9.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (>=20.0.1)", "requests (>=2.31.0)"]
+
+[[package]]
+name = "redisvl"
+version = "0.8.2"
+description = "Python client library and CLI for using Redis as a vector database"
+optional = false
+python-versions = "<3.14,>=3.9"
+groups = ["main"]
+files = [
+    {file = "redisvl-0.8.2-py3-none-any.whl", hash = "sha256:67b413387d72849d571723c95fa1183539d6fa60d6ac533513ee8e3e31874600"},
+    {file = "redisvl-0.8.2.tar.gz", hash = "sha256:3938ddcd093507c4c427cb431ac9faaa8bb999bb2ca116cbd57e4b7334fe18eb"},
+]
+
+[package.dependencies]
+jsonpath-ng = ">=1.5.0"
+ml-dtypes = ">=0.4.0,<1.0.0"
+numpy = ">=1.26.0,<3"
+pydantic = ">=2,<3"
+python-ulid = ">=3.0.0"
+pyyaml = ">=5.4,<7.0"
+redis = ">=5.0,<7.0"
+tenacity = ">=8.2.2"
+
+[package.extras]
+bedrock = ["boto3 (>=1.36.0,<2)", "urllib3 (<2.2.0)"]
+cohere = ["cohere (>=4.44)"]
+mistralai = ["mistralai (>=1.0.0)"]
+nltk = ["nltk (>=3.8.1,<4)"]
+openai = ["openai (>=1.1.0)"]
+sentence-transformers = ["sentence-transformers (>=3.4.0,<4)"]
+vertexai = ["google-cloud-aiplatform (>=1.26,<2.0.0)", "protobuf (>=5.28.0,<6.0.0)"]
+voyageai = ["voyageai (>=0.2.2)"]
 
 [[package]]
 name = "referencing"
@@ -5473,4 +5634,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "3.12.*"
-content-hash = "cb756b095e5a73b15b814fc82a726f212dd081b02dcc72af3c2acaafbdfd0053"
+content-hash = "6d18ac0bef80aeb6cadae0a760e940d54caac40fa373daea3b44700b08d2e4f9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ pandas = "^2.2.1"
 pyarrow = "^21.0.0"
 datasets = "^2.20.0"
 tavily-python = "^0.7.11"
+langgraph-checkpoint-redis = "^0.1.1"
+redis = "^6.4.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.1"

--- a/src/agentic_rag/app/api.py
+++ b/src/agentic_rag/app/api.py
@@ -31,9 +31,11 @@ from agentic_rag.app.agentic_workflow import (
     smart_retrieval_and_rerank,
     hybrid_context_retrieval,
 )
-from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.checkpoint.redis.aio import AsyncRedisSaver
 import uuid
 from agentic_rag.logging_config import setup_logging, logger
+from agentic_rag.config import settings
+from agentic_rag.app.middlewares import RequestIDMiddleware
 
 # --- Setup Logging ---
 setup_logging()
@@ -43,129 +45,136 @@ setup_logging()
 async def lifespan(app: FastAPI):
     logger.info("--- Building and compiling autonomous LangGraph app at startup ---")
 
-    workflow = StateGraph(GraphState)
+    # --- Use Redis for persistent, shareable state ---
+    async with AsyncRedisSaver.from_conn_string(
+        f"redis://{settings.REDIS_HOST}:6379"
+    ) as checkpointer:
+        # This is the critical setup step that was missing.
+        await checkpointer.asetup()
 
-    # --- Add all ACTION nodes to the graph ---
-    workflow.add_node("classify_query", classify_query)
-    workflow.add_node("transform_query", transform_query)
-    workflow.add_node("generate_hyde_document", generate_hyde_document)
-    workflow.add_node("web_search", web_search)
-    workflow.add_node("retrieve_docs", retrieve_documents)
-    workflow.add_node("rerank_documents", grade_and_rerank_documents)
-    workflow.add_node("summarize_history", summarize_history)
-    workflow.add_node("generate_answer", generate_answer)
-    workflow.add_node("safety_check", grounding_and_safety_check)
-    workflow.add_node("web_search_safety_check", web_search_safety_check)
+        workflow = StateGraph(GraphState)
 
-    # Nodes for the retrieval correction loop
-    workflow.add_node("enter_retrieval_correction", increment_retrieval_retry_counter)
-    workflow.add_node("handle_retrieval_failure", handle_retrieval_failure)
+        # --- Add all ACTION nodes to the graph ---
+        workflow.add_node("classify_query", classify_query)
+        workflow.add_node("transform_query", transform_query)
+        workflow.add_node("generate_hyde_document", generate_hyde_document)
+        workflow.add_node("web_search", web_search)
+        workflow.add_node("retrieve_docs", retrieve_documents)
+        workflow.add_node("rerank_documents", grade_and_rerank_documents)
+        workflow.add_node("summarize_history", summarize_history)
+        workflow.add_node("generate_answer", generate_answer)
+        workflow.add_node("safety_check", grounding_and_safety_check)
+        workflow.add_node("web_search_safety_check", web_search_safety_check)
 
-    # Nodes for the grounding correction loop
-    workflow.add_node("enter_grounding_correction", increment_grounding_retry_counter)
-    workflow.add_node("smart_retrieval", smart_retrieval_and_rerank)
-    workflow.add_node("hybrid_context", hybrid_context_retrieval)
-    workflow.add_node("handle_grounding_failure", handle_grounding_failure)
+        # Nodes for the retrieval correction loop
+        workflow.add_node("enter_retrieval_correction", increment_retrieval_retry_counter)
+        workflow.add_node("handle_retrieval_failure", handle_retrieval_failure)
 
-    # --- Set up the graph's edges and conditional routing ---
-    workflow.set_entry_point("classify_query")
+        # Nodes for the grounding correction loop
+        workflow.add_node("enter_grounding_correction", increment_grounding_retry_counter)
+        workflow.add_node("smart_retrieval", smart_retrieval_and_rerank)
+        workflow.add_node("hybrid_context", hybrid_context_retrieval)
+        workflow.add_node("handle_grounding_failure", handle_grounding_failure)
 
-    workflow.add_conditional_edges(
-        "classify_query",
-        route_for_retrieval,
-        {"transform_query": "transform_query", "retrieve": "retrieve_docs"},
-    )
+        # --- Set up the graph's edges and conditional routing ---
+        workflow.set_entry_point("classify_query")
 
-    workflow.add_edge("transform_query", "retrieve_docs")
+        workflow.add_conditional_edges(
+            "classify_query",
+            route_for_retrieval,
+            {"transform_query": "transform_query", "retrieve": "retrieve_docs"},
+        )
 
-    workflow.add_conditional_edges(
-        "retrieve_docs",
-        route_after_retrieval,
-        {
-            "rerank_documents": "rerank_documents",
-            "enter_retrieval_correction": "enter_retrieval_correction",
-        },
-    )
+        workflow.add_edge("transform_query", "retrieve_docs")
 
-    workflow.add_conditional_edges(
-        "rerank_documents",
-        route_after_reranking,
-        {
-            "summarize": "summarize_history",
-            "enter_retrieval_correction": "enter_retrieval_correction",
-        },
-    )
+        workflow.add_conditional_edges(
+            "retrieve_docs",
+            route_after_retrieval,
+            {
+                "rerank_documents": "rerank_documents",
+                "enter_retrieval_correction": "enter_retrieval_correction",
+            },
+        )
 
-    # --- Retrieval Self-Correction Loop ---
-    workflow.add_conditional_edges(
-        "enter_retrieval_correction",
-        route_retrieval_correction,
-        {
-            "transform_query": "transform_query",
-            "generate_hyde_document": "generate_hyde_document",
-            "web_search": "web_search",
-            "handle_retrieval_failure": "handle_retrieval_failure",
-        },
-    )
-    workflow.add_edge("generate_hyde_document", "retrieve_docs")
+        workflow.add_conditional_edges(
+            "rerank_documents",
+            route_after_reranking,
+            {
+                "summarize": "summarize_history",
+                "enter_retrieval_correction": "enter_retrieval_correction",
+            },
+        )
 
-    # --- Generation Path ---
-    workflow.add_edge("summarize_history", "generate_answer")
-    workflow.add_edge("web_search", "summarize_history")
+        # --- Retrieval Self-Correction Loop ---
+        workflow.add_conditional_edges(
+            "enter_retrieval_correction",
+            route_retrieval_correction,
+            {
+                "transform_query": "transform_query",
+                "generate_hyde_document": "generate_hyde_document",
+                "web_search": "web_search",
+                "handle_retrieval_failure": "handle_retrieval_failure",
+            },
+        )
+        workflow.add_edge("generate_hyde_document", "retrieve_docs")
 
-    workflow.add_conditional_edges(
-        "generate_answer",
-        route_after_generation,
-        {
-            "safety_check": "safety_check",
-            "web_search_safety_check": "web_search_safety_check",
-        },
-    )
+        # --- Generation Path ---
+        workflow.add_edge("summarize_history", "generate_answer")
+        workflow.add_edge("web_search", "summarize_history")
 
-    # --- Advanced Grounding Self-Correction Loop ---
-    workflow.add_conditional_edges(
-        "safety_check",
-        route_after_safety_check,
-        {"END": END, "enter_grounding_correction": "enter_grounding_correction"},
-    )
-    workflow.add_conditional_edges(
-        "enter_grounding_correction",
-        route_grounding_correction,
-        {
-            "smart_retrieval": "smart_retrieval",
-            "hybrid_context": "hybrid_context",
-            "handle_grounding_failure": "handle_grounding_failure",
-        },
-    )
-    workflow.add_edge("smart_retrieval", "generate_answer")
-    workflow.add_edge("hybrid_context", "generate_answer")
+        workflow.add_conditional_edges(
+            "generate_answer",
+            route_after_generation,
+            {
+                "safety_check": "safety_check",
+                "web_search_safety_check": "web_search_safety_check",
+            },
+        )
 
-    # --- Endpoints ---
-    workflow.add_edge("handle_retrieval_failure", END)
-    workflow.add_edge("handle_grounding_failure", END)
-    workflow.add_edge("web_search_safety_check", END)
+        # --- Advanced Grounding Self-Correction Loop ---
+        workflow.add_conditional_edges(
+            "safety_check",
+            route_after_safety_check,
+            {"END": END, "enter_grounding_correction": "enter_grounding_correction"},
+        )
+        workflow.add_conditional_edges(
+            "enter_grounding_correction",
+            route_grounding_correction,
+            {
+                "smart_retrieval": "smart_retrieval",
+                "hybrid_context": "hybrid_context",
+                "handle_grounding_failure": "handle_grounding_failure",
+            },
+        )
+        workflow.add_edge("smart_retrieval", "generate_answer")
+        workflow.add_edge("hybrid_context", "generate_answer")
 
-    # --- Add a memory checkpointer ---
-    memory = InMemorySaver()
+        # --- Endpoints ---
+        workflow.add_edge("handle_retrieval_failure", END)
+        workflow.add_edge("handle_grounding_failure", END)
+        workflow.add_edge("web_search_safety_check", END)
 
-    app.state.langgraph_app = workflow.compile(checkpointer=memory)
+        app.state.langgraph_app = workflow.compile(checkpointer=checkpointer)
+        logger.info("--- LangGraph app compiled successfully ---")
 
-    logger.info("--- LangGraph app compiled successfully ---")
+        # --- Save the graph as a Mermaid markdown file ---
+        try:
+            graph_mermaid = app.state.langgraph_app.get_graph(xray=True).draw_mermaid()
+            with open("autonomous_rag_graph.md", "w") as f:
+                f.write(graph_mermaid)
+            logger.info("--- Graph visualization saved to autonomous_rag_graph.md ---")
+        except Exception as e:
+            logger.error(f"Failed to generate graph visualization: {e}")
 
-    # --- Save the graph as a Mermaid markdown file ---
-    try:
-        graph_mermaid = app.state.langgraph_app.get_graph(xray=True).draw_mermaid()
-        with open("autonomous_rag_graph.md", "w") as f:
-            f.write(graph_mermaid)
-        logger.info("--- Graph visualization saved to autonomous_rag_graph.md ---")
-    except Exception as e:
-        logger.error(f"Failed to generate graph visualization: {e}")
+        yield
 
-    yield
-    logger.info("--- Application shutdown ---")
+logger.info("--- Application shutdown ---")
 
 
 app = FastAPI(lifespan=lifespan)
+
+# Add the RequestIDMiddleware to the application
+app.add_middleware(RequestIDMiddleware)
 
 
 class QueryRequest(BaseModel):
@@ -192,7 +201,7 @@ async def query_endpoint(request: QueryRequest):
     inputs = {"messages": [HumanMessage(content=request.query)]}
     config = {"configurable": {"thread_id": session_id}}
 
-    final_state = langgraph_app.invoke(inputs, config=config)
+    final_state = await langgraph_app.ainvoke(inputs, config=config)
 
     answer = final_state["messages"][-1].content
 

--- a/src/agentic_rag/app/api.py
+++ b/src/agentic_rag/app/api.py
@@ -67,11 +67,15 @@ async def lifespan(app: FastAPI):
         workflow.add_node("web_search_safety_check", web_search_safety_check)
 
         # Nodes for the retrieval correction loop
-        workflow.add_node("enter_retrieval_correction", increment_retrieval_retry_counter)
+        workflow.add_node(
+            "enter_retrieval_correction", increment_retrieval_retry_counter
+        )
         workflow.add_node("handle_retrieval_failure", handle_retrieval_failure)
 
         # Nodes for the grounding correction loop
-        workflow.add_node("enter_grounding_correction", increment_grounding_retry_counter)
+        workflow.add_node(
+            "enter_grounding_correction", increment_grounding_retry_counter
+        )
         workflow.add_node("smart_retrieval", smart_retrieval_and_rerank)
         workflow.add_node("hybrid_context", hybrid_context_retrieval)
         workflow.add_node("handle_grounding_failure", handle_grounding_failure)
@@ -167,6 +171,7 @@ async def lifespan(app: FastAPI):
             logger.error(f"Failed to generate graph visualization: {e}")
 
         yield
+
 
 logger.info("--- Application shutdown ---")
 

--- a/src/agentic_rag/app/middlewares.py
+++ b/src/agentic_rag/app/middlewares.py
@@ -9,11 +9,13 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 # A context variable to hold the request ID for the duration of a request.
 REQUEST_ID_CTX_VAR: ContextVar[Optional[str]] = ContextVar("request_id", default=None)
 
+
 class RequestIDMiddleware(BaseHTTPMiddleware):
     """
     Injects a unique X-Request-ID header into every request.
     This ID is then available throughout the application via a context variable.
     """
+
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint):
         request_id = request.headers.get("X-Request-ID")
         if not request_id:

--- a/src/agentic_rag/app/middlewares.py
+++ b/src/agentic_rag/app/middlewares.py
@@ -1,0 +1,29 @@
+# src/agentic_rag/app/middlewares.py
+
+import uuid
+from contextvars import ContextVar
+from typing import Optional
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+
+# A context variable to hold the request ID for the duration of a request.
+REQUEST_ID_CTX_VAR: ContextVar[Optional[str]] = ContextVar("request_id", default=None)
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """
+    Injects a unique X-Request-ID header into every request.
+    This ID is then available throughout the application via a context variable.
+    """
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint):
+        request_id = request.headers.get("X-Request-ID")
+        if not request_id:
+            request_id = str(uuid.uuid4())
+
+        # Set the context variable
+        REQUEST_ID_CTX_VAR.set(request_id)
+
+        response = await call_next(request)
+
+        # Also add the ID to the response headers
+        response.headers["X-Request-ID"] = request_id
+        return response

--- a/src/agentic_rag/config.py
+++ b/src/agentic_rag/config.py
@@ -11,7 +11,7 @@ class Settings(BaseSettings):
 
     # --- New Redis Setting ---
     REDIS_HOST: str = "localhost"
-    
+
     # --- Provider Settings ---
     LLM_PROVIDER: Literal["openai", "google"] = "openai"
 
@@ -43,5 +43,6 @@ class Settings(BaseSettings):
     CROSS_ENCODER_MODEL_SMALL: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"
     CROSS_ENCODER_MODEL_LARGE: str = "cross-encoder/ms-marco-MiniLM-L-12-v2"
     CROSS_ENCODER_MODEL_ROBERTA: str = "cross-encoder/stsb-roberta-large"
+
 
 settings = Settings()

--- a/src/agentic_rag/config.py
+++ b/src/agentic_rag/config.py
@@ -9,6 +9,9 @@ class Settings(BaseSettings):
         env_file=".env", env_file_encoding="utf-8", extra="ignore"
     )
 
+    # --- New Redis Setting ---
+    REDIS_HOST: str = "localhost"
+    
     # --- Provider Settings ---
     LLM_PROVIDER: Literal["openai", "google"] = "openai"
 
@@ -40,6 +43,5 @@ class Settings(BaseSettings):
     CROSS_ENCODER_MODEL_SMALL: str = "cross-encoder/ms-marco-MiniLM-L-6-v2"
     CROSS_ENCODER_MODEL_LARGE: str = "cross-encoder/ms-marco-MiniLM-L-12-v2"
     CROSS_ENCODER_MODEL_ROBERTA: str = "cross-encoder/stsb-roberta-large"
-
 
 settings = Settings()

--- a/src/agentic_rag/logging_config.py
+++ b/src/agentic_rag/logging_config.py
@@ -10,9 +10,10 @@ class CustomJsonFormatter(jsonlogger.JsonFormatter):
     """
     A custom JSON log formatter that adds the request_id from a context variable.
     """
+
     def add_fields(self, log_record, record, message_dict):
         super(CustomJsonFormatter, self).add_fields(log_record, record, message_dict)
-        log_record['request_id'] = REQUEST_ID_CTX_VAR.get()
+        log_record["request_id"] = REQUEST_ID_CTX_VAR.get()
 
 
 # Suppress the specific Protobuf UserWarning from the gRPC libraries

--- a/src/agentic_rag/logging_config.py
+++ b/src/agentic_rag/logging_config.py
@@ -2,6 +2,18 @@
 
 import logging.config
 import warnings
+from pythonjsonlogger import jsonlogger
+from agentic_rag.app.middlewares import REQUEST_ID_CTX_VAR
+
+
+class CustomJsonFormatter(jsonlogger.JsonFormatter):
+    """
+    A custom JSON log formatter that adds the request_id from a context variable.
+    """
+    def add_fields(self, log_record, record, message_dict):
+        super(CustomJsonFormatter, self).add_fields(log_record, record, message_dict)
+        log_record['request_id'] = REQUEST_ID_CTX_VAR.get()
+
 
 # Suppress the specific Protobuf UserWarning from the gRPC libraries
 warnings.filterwarnings("ignore", message="Protobuf gencode version.*")

--- a/ui/streamlit_app.py
+++ b/ui/streamlit_app.py
@@ -1,7 +1,17 @@
-# ui.py
+# ui/streamlit_app.py
 
 import streamlit as st
 import requests
+import sys
+import os
+
+# Add the project's 'src' directory to the Python path
+# This is necessary for the logging.ini to find the custom formatter
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+src_path = os.path.join(project_root, "src")
+if src_path not in sys.path:
+    sys.path.insert(0, src_path)
+
 from agentic_rag.logging_config import setup_logging
 
 # --- Setup Logging ---


### PR DESCRIPTION
### Externalize State
- Make the backend API stateless by storing conversational checkpoints in Redis instead of in-memory.
- The code in src/agentic_rag/app/api.py still uses the InMemorySaver. The next step is to add the langgraph-checkpoint-redis dependency and switch to using AsyncRedisSaver.


### Implement the Correlation ID middleware for traceability
- Add a unique ID to every request and include it in all logs, making it possible to trace a single user's journey through our distributed system.
- Create the file src/agentic_rag/app/middlewares.py
- Set up a contextvar to hold the request ID and a middleware to manage it.